### PR TITLE
Add missing code fencing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,8 @@ pub trait UnicodeSegmentation {
     /// [General_Category=Number](http://unicode.org/reports/tr44/#General_Category_Values).
     ///
     /// # Example
+    ///
+    /// ```
     /// # use self::unicode_segmentation::UnicodeSegmentation;
     /// let uws = "The quick (\"brown\") fox can't jump 32.3 feet, right?";
     /// let uw1 = uws.unicode_words().collect::<Vec<&str>>();


### PR DESCRIPTION
Fixes missing [code syntax highlighting](https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/trait.UnicodeSegmentation.html#tymethod.unicode_words)