### PR TITLE
Make no_std the default; remove optional Cargo feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ language: rust
 rust: 'nightly'
 sudo: false
 script:
-  - cargo build --verbose --features no_std
-  - cargo test --verbose --features no_std
-  - cargo clean
-  - cargo build --verbose --features default
-  - cargo test --verbose --features default
+  - cargo build --verbose
+  - cargo test --verbose
   - rustdoc --test README.md -L target/debug -L target/debug/deps
   - cargo doc
 after_success: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unicode-segmentation"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["kwantam <kwantam@gmail.com>"]
 
 homepage = "https://github.com/unicode-rs/unicode-segmentation"
@@ -19,5 +19,4 @@ according to Unicode Standard Annex #29 rules.
 exclude = [ "target/*", "Cargo.lock", "scripts/tmp" ]
 
 [features]
-default = []
-no_std = []
+no_std = [] # This is a no-op, preserved for backward compatibility only.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ fn main() {
 }
 ```
 
-# features
+# no_std
 
-unicode-segmentation supports a `no_std` feature. This eliminates dependence on std,
-and instead uses equivalent functions from core.
+unicode-segmentation does not depend on libstd, so it can be used in crates
+with the `#![no_std]` attribute.
 
 # crates.io
 

--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -210,13 +210,7 @@ def emit_util_mod(f):
 pub mod util {
     #[inline]
     pub fn bsearch_range_table(c: char, r: &'static [(char,char)]) -> bool {
-        #[cfg(feature = "no_std")]
         use core::cmp::Ordering::{Equal, Less, Greater};
-        #[cfg(feature = "no_std")]
-        use core::slice::SliceExt;
-        
-        #[cfg(not(feature = "no_std"))]
-        use std::cmp::Ordering::{Equal, Less, Greater};
         r.binary_search_by(|&(lo,hi)| {
             if lo <= c && c <= hi { Equal }
             else if hi < c { Less }
@@ -263,9 +257,7 @@ def emit_property_module(f, mod, tbl, emit):
 def emit_break_module(f, break_table, break_cats, name):
     Name = name.capitalize()
     f.write("""pub mod %s {
-    #[cfg(feature = "no_std")]
     use core::slice::SliceExt;
-    #[cfg(feature = "no_std")]
     use core::result::Result::{Ok, Err};
 
     pub use self::%sCat::*;
@@ -282,10 +274,7 @@ def emit_break_module(f, break_table, break_cats, name):
     f.write("""    }
 
     fn bsearch_range_value_table(c: char, r: &'static [(char, char, %sCat)]) -> %sCat {
-        #[cfg(feature = "no_std")]
         use core::cmp::Ordering::{Equal, Less, Greater};
-        #[cfg(not(feature = "no_std"))]
-        use std::cmp::Ordering::{Equal, Less, Greater};
         match r.binary_search_by(|&(lo, hi, _)| {
             if lo <= c && c <= hi { Equal }
             else if hi < c { Less }

--- a/src/grapheme.rs
+++ b/src/grapheme.rs
@@ -8,11 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(feature = "no_std")]
 use core::cmp;
-
-#[cfg(not(feature = "no_std"))]
-use std::cmp;
 
 use tables::grapheme::GraphemeCat;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,15 +34,15 @@
 //! }
 //! ```
 //!
+//! # no_std
+//!
+//! unicode-segmentation does not depend on libstd, so it can be used in crates
+//! with the `#![no_std]` attribute.
+//!
 //! # crates.io
 //!
 //! You can use this package in your project by adding the following
 //! to your `Cargo.toml`:
-//!
-//! # features
-//!
-//! unicode-segmentation supports a `no_std` feature. This eliminates dependence on std,
-//! and instead uses equivalent functions from core.
 //!
 //! ```toml
 //! [dependencies]
@@ -53,10 +53,9 @@
 #![doc(html_logo_url = "https://unicode-rs.github.io/unicode-rs_sm.png",
        html_favicon_url = "https://unicode-rs.github.io/unicode-rs_sm.png")]
 
-#![cfg_attr(feature = "no_std", no_std)]
-#![cfg_attr(feature = "no_std", feature(no_std, core_char_ext, core_slice_ext, core_str_ext))]
+#![no_std]
 
-#[cfg(all(test, feature = "no_std"))]
+#[cfg(test)]
 #[macro_use]
 extern crate std;
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -19,13 +19,7 @@ pub const UNICODE_VERSION: (u64, u64, u64) = (8, 0, 0);
 pub mod util {
     #[inline]
     pub fn bsearch_range_table(c: char, r: &'static [(char,char)]) -> bool {
-        #[cfg(feature = "no_std")]
         use core::cmp::Ordering::{Equal, Less, Greater};
-        #[cfg(feature = "no_std")]
-        use core::slice::SliceExt;
-        
-        #[cfg(not(feature = "no_std"))]
-        use std::cmp::Ordering::{Equal, Less, Greater};
         r.binary_search_by(|&(lo,hi)| {
             if lo <= c && c <= hi { Equal }
             else if hi < c { Less }
@@ -285,9 +279,6 @@ mod derived_property {
 }
 
 pub mod grapheme {
-    #[cfg(feature = "no_std")]
-    use core::slice::SliceExt;
-    #[cfg(feature = "no_std")]
     use core::result::Result::{Ok, Err};
 
     pub use self::GraphemeCat::*;
@@ -308,10 +299,7 @@ pub mod grapheme {
     }
 
     fn bsearch_range_value_table(c: char, r: &'static [(char, char, GraphemeCat)]) -> GraphemeCat {
-        #[cfg(feature = "no_std")]
         use core::cmp::Ordering::{Equal, Less, Greater};
-        #[cfg(not(feature = "no_std"))]
-        use std::cmp::Ordering::{Equal, Less, Greater};
         match r.binary_search_by(|&(lo, hi, _)| {
             if lo <= c && c <= hi { Equal }
             else if hi < c { Less }
@@ -829,9 +817,6 @@ pub mod grapheme {
 }
 
 pub mod word {
-    #[cfg(feature = "no_std")]
-    use core::slice::SliceExt;
-    #[cfg(feature = "no_std")]
     use core::result::Result::{Ok, Err};
 
     pub use self::WordCat::*;
@@ -859,10 +844,7 @@ pub mod word {
     }
 
     fn bsearch_range_value_table(c: char, r: &'static [(char, char, WordCat)]) -> WordCat {
-        #[cfg(feature = "no_std")]
         use core::cmp::Ordering::{Equal, Less, Greater};
-        #[cfg(not(feature = "no_std"))]
-        use std::cmp::Ordering::{Equal, Less, Greater};
         match r.binary_search_by(|&(lo, hi, _)| {
             if lo <= c && c <= hi { Equal }
             else if hi < c { Less }

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,7 +10,6 @@
 
 use super::UnicodeSegmentation;
 
-#[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 
 #[test]

--- a/src/word.rs
+++ b/src/word.rs
@@ -8,15 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(feature = "no_std")]
 use core::cmp;
-#[cfg(feature = "no_std")]
 use core::iter::Filter;
-
-#[cfg(not(feature = "no_std"))]
-use std::cmp;
-#[cfg(not(feature = "no_std"))]
-use std::iter::Filter;
 
 use tables::word::WordCat;
 


### PR DESCRIPTION
All of the libcore functionality used in this crate is now stable, so it is no longer necessary to disable it for compatibility with the Rust stable channel.