### PR TITLE
Add as_str methods to iterator types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unicode-segmentation"
-version = "1.0.3"
+version = "1.1.0"
 authors = ["kwantam <kwantam@gmail.com>"]
 
 homepage = "https://github.com/unicode-rs/unicode-segmentation"

--- a/README.md
+++ b/README.md
@@ -40,5 +40,23 @@ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-unicode-segmentation = "1.0.2"
+unicode-segmentation = "1.1.0"
 ```
+
+# Change Log
+
+## 1.1.0
+
+* Add `as_str` methods to the iterator types.
+
+## 1.0.3
+
+* Code cleanup and additional tests.
+
+## 1.0.1
+
+* Fix a bug affecting some grapheme clusters containing Prepend characters.
+
+## 1.0.0
+
+* Upgrade to Unicode 9.0.0.

--- a/src/grapheme.rs
+++ b/src/grapheme.rs
@@ -19,6 +19,25 @@ pub struct GraphemeIndices<'a> {
     iter: Graphemes<'a>,
 }
 
+impl<'a> GraphemeIndices<'a> {
+    #[inline]
+    /// View the underlying data (the part yet to be iterated) as a slice of the original string.
+    ///
+    /// ```rust
+    /// # use unicode_segmentation::UnicodeSegmentation;
+    /// let mut iter = "abc".grapheme_indices(true);
+    /// assert_eq!(iter.as_str(), "abc");
+    /// iter.next();
+    /// assert_eq!(iter.as_str(), "bc");
+    /// iter.next();
+    /// iter.next();
+    /// assert_eq!(iter.as_str(), "");
+    /// ```
+    pub fn as_str(&self) -> &'a str {
+        self.iter.as_str()
+    }
+}
+
 impl<'a> Iterator for GraphemeIndices<'a> {
     type Item = (usize, &'a str);
 
@@ -49,6 +68,25 @@ pub struct Graphemes<'a> {
     cat: Option<GraphemeCat>,
     catb: Option<GraphemeCat>,
     regional_count_back: Option<usize>,
+}
+
+impl<'a> Graphemes<'a> {
+    #[inline]
+    /// View the underlying data (the part yet to be iterated) as a slice of the original string.
+    ///
+    /// ```rust
+    /// # use unicode_segmentation::UnicodeSegmentation;
+    /// let mut iter = "abc".graphemes(true);
+    /// assert_eq!(iter.as_str(), "abc");
+    /// iter.next();
+    /// assert_eq!(iter.as_str(), "bc");
+    /// iter.next();
+    /// iter.next();
+    /// assert_eq!(iter.as_str(), "");
+    /// ```
+    pub fn as_str(&self) -> &'a str {
+        self.string
+    }
 }
 
 // state machine for cluster boundary rules

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! unicode-segmentation = "1.0.2"
+//! unicode-segmentation = "1.1.0"
 //! ```
 
 #![deny(missing_docs, unsafe_code)]

--- a/src/word.rs
+++ b/src/word.rs
@@ -50,6 +50,24 @@ pub struct UWordBoundIndices<'a> {
     iter: UWordBounds<'a>,
 }
 
+impl<'a> UWordBoundIndices<'a> {
+    #[inline]
+    /// View the underlying data (the part yet to be iterated) as a slice of the original string.
+    ///
+    /// ```rust
+    /// # use unicode_segmentation::UnicodeSegmentation;
+    /// let mut iter = "Hello world".split_word_bound_indices();
+    /// assert_eq!(iter.as_str(), "Hello world");
+    /// iter.next();
+    /// assert_eq!(iter.as_str(), " world");
+    /// iter.next();
+    /// assert_eq!(iter.as_str(), "world");
+    /// ```
+    pub fn as_str(&self) -> &'a str {
+        self.iter.as_str()
+    }
+}
+
 impl<'a> Iterator for UWordBoundIndices<'a> {
     type Item = (usize, &'a str);
 
@@ -569,6 +587,22 @@ impl<'a> DoubleEndedIterator for UWordBounds<'a> {
 }
 
 impl<'a> UWordBounds<'a> {
+    #[inline]
+    /// View the underlying data (the part yet to be iterated) as a slice of the original string.
+    ///
+    /// ```rust
+    /// # use unicode_segmentation::UnicodeSegmentation;
+    /// let mut iter = "Hello world".split_word_bounds();
+    /// assert_eq!(iter.as_str(), "Hello world");
+    /// iter.next();
+    /// assert_eq!(iter.as_str(), " world");
+    /// iter.next();
+    /// assert_eq!(iter.as_str(), "world");
+    /// ```
+    pub fn as_str(&self) -> &'a str {
+        self.string
+    }
+
     #[inline]
     fn get_next_cat(&self, idx: usize) -> Option<WordCat> {
         use tables::word as wd;


### PR DESCRIPTION
This is based on standard library methods like [Chars::as_str][1].

[1]: https://doc.rust-lang.org/std/str/struct.Chars.html#method.as_str