### PR TITLE
Bump to 1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unicode-segmentation"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["kwantam <kwantam@gmail.com>"]
 
 homepage = "https://github.com/unicode-rs/unicode-segmentation"


### PR DESCRIPTION
Semimajor bump because of the extra rope API. No breaking changes, but it deserves a fresh version. Will make it 1.1.1 instead if y'all think that should be the case.


r? @SimonSapin @kwantam