### PR TITLE
travis: also test with minimum supported Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
-rust: stable
+rust:
+  - 1.24.0
+  - stable
 os: linux
 script:
   - cargo build --verbose
@@ -7,6 +9,7 @@ script:
   - rustdoc --test README.md -L target/debug -L target/debug/deps
   - cargo doc
 after_success: |
+  [ $TRAVIS_RUST_VERSION = stable ] &&
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&
   echo '<meta http-equiv=refresh content=0;url=unicode_segmentation/index.html>' > target/doc/index.html &&


### PR DESCRIPTION
The 1.2.0 release increased the minimum supported version of Rust from
below 1.11.0 to 1.13.0 due to the introduction of code that use the
"?" operator. This caused unexpected build failures in dependent
crates, such as clap.

This PR updates Travis to also test against the current minimum
version. Changes to this version will thus fail PRs and it will become
an active decision to bump the minimum supported Rust version.

Between this PR was originally made and today, the minimum version
increased further and the earliest version where I can get the crate
to compile is now Rust 1.24.0.

Fixes #26.