### PR TITLE
Docs: clarify behavior of `UWordBoundIndices`

### DIFF
--- a/src/word.rs
+++ b/src/word.rs
@@ -44,6 +44,9 @@ pub struct UWordBounds<'a> {
 }
 
 /// External iterator for word boundaries and byte offsets.
+///
+/// Yields `(usize, &str)` pairs carrying string slices delimited by word
+/// boundaries and their positions.
 #[derive(Clone)]
 pub struct UWordBoundIndices<'a> {
     start_offset: usize,


### PR DESCRIPTION
Briefly document the iterator behavior of `UWordBoundIndices` on the struct itself.

Closes  #35.