### PR TITLE
Updates README Cargo.toml example to mention 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-unicode-segmentation = "1.1.0"
+unicode-segmentation = "1.2.0"
 ```
 
 # Change Log


### PR DESCRIPTION
This is the latest released version, maybe got forgotten when upgrading?