### PR TITLE
Ensure version number consistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ no_std = [] # This is a no-op, preserved for backward compatibility only.
 
 [dev-dependencies]
 quickcheck = "0.7"
+version-sync = "0.8"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ unicode-segmentation = "1.2.1"
 
 # Change Log
 
+## 1.2.1
+
+* [#37](https://github.com/unicode-rs/unicode-segmentation/pull/37):
+  Fix panic in `provide_context`.
+* [#40](https://github.com/unicode-rs/unicode-segmentation/pull/40):
+  Fix crash in `prev_boundary`.
+
 ## 1.2.0
 
 * New `GraphemeCursor` API allows random access and bidirectional iteration.

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,0 +1,14 @@
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_readme_changelog() {
+    version_sync::assert_contains_regex!("README.md", r"^## {version}$");
+}
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
This adds a test that will check the examples in README.md for the
current package version.

It also checks that there is a Markdown heading mentioning (at least)
the current version. This serves as a simple check that the change log
section is updated when the version number is bumped.

Related to #30, #41, #47, and #48.