### PR TITLE
readme: add changelog for 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ unicode-segmentation = "1.2.1"
 
 # Change Log
 
+## 1.2.1
+
+* [#37](https://github.com/unicode-rs/unicode-segmentation/pull/37):
+  Fix panic in `provide_context`.
+* [#40](https://github.com/unicode-rs/unicode-segmentation/pull/40):
+  Fix crash in `prev_boundary`.
+
 ## 1.2.0
 
 * New `GraphemeCursor` API allows random access and bidirectional iteration.


### PR DESCRIPTION
This seems to have been forgotten in 703e9c25.

This was originally proposed in #27, but got reverted in a91ee39 along with other changes.