### PR TITLE
Update version in docs to 1.2.1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! unicode-segmentation = "1.1.0"
+//! unicode-segmentation = "1.2.1"
 //! ```
 
 #![deny(missing_docs, unsafe_code)]


### PR DESCRIPTION
Update doc version to match current version. 

I noticed this was out of date on the doc page: https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/index.html

I think the generated source the the website will need to get updated after this: https://github.com/unicode-rs/unicode-rs.github.io