### PR TITLE
fix: use inclusive range

### DIFF
--- a/src/tables.rs
+++ b/src/tables.rs
@@ -30,7 +30,7 @@ pub mod util {
     #[inline]
     fn is_alphabetic(c: char) -> bool {
         match c {
-            'a' ... 'z' | 'A' ... 'Z' => true,
+            'a' ..= 'z' | 'A' ..= 'Z' => true,
             c if c > '' => super::derived_property::Alphabetic(c),
             _ => false,
         }
@@ -39,7 +39,7 @@ pub mod util {
     #[inline]
     fn is_numeric(c: char) -> bool {
         match c {
-            '0' ... '9' => true,
+            '0' ..= '9' => true,
             c if c > '' => super::general_category::N(c),
             _ => false,
         }


### PR DESCRIPTION
Fixes: https://github.com/unicode-rs/unicode-segmentation/issues/63

Note: The inclusive range pattern syntax was introduced in [rust v1.26.0](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1260-2018-05-10)