### PR TITLE
Update docs to point to current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-unicode-segmentation = "1.3.0"
+unicode-segmentation = "1.6.0"
 ```
 
 # Change Log

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! unicode-segmentation = "1.3.0"
+//! unicode-segmentation = "1.6.0"
 //! ```
 
 #![deny(missing_docs, unsafe_code)]


### PR DESCRIPTION
This PR just updates the docs from specifying `1.3.0` to `1.6.0`, so if folks are copy/pasting (like me), there's less surprises.