### PR TITLE
Add unicode_word_indices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ extern crate quickcheck;
 pub use grapheme::{Graphemes, GraphemeIndices};
 pub use grapheme::{GraphemeCursor, GraphemeIncomplete};
 pub use tables::UNICODE_VERSION;
-pub use word::{UWordBounds, UWordBoundIndices, UnicodeWords};
+pub use word::{UWordBounds, UWordBoundIndices, UnicodeWords, UnicodeWordIndices};
 pub use sentence::{USentenceBounds, USentenceBoundIndices, UnicodeSentences};
 
 mod grapheme;
@@ -145,6 +145,30 @@ pub trait UnicodeSegmentation {
     /// assert_eq!(&uw1[..], b);
     /// ```
     fn unicode_words<'a>(&'a self) -> UnicodeWords<'a>;
+
+    /// Returns an iterator over the words of `self`, separated on
+    /// [UAX#29 word boundaries](http://www.unicode.org/reports/tr29/#Word_Boundaries), and their
+    /// offsets.
+    ///
+    /// Here, "words" are just those substrings which, after splitting on
+    /// UAX#29 word boundaries, contain any alphanumeric characters. That is, the
+    /// substring must contain at least one character with the
+    /// [Alphabetic](http://unicode.org/reports/tr44/#Alphabetic)
+    /// property, or with
+    /// [General_Category=Number](http://unicode.org/reports/tr44/#General_Category_Values).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use self::unicode_segmentation::UnicodeSegmentation;
+    /// let uwis = "The quick (\"brown\") fox can't jump 32.3 feet, right?";
+    /// let uwi1 = uwis.unicode_word_indices().collect::<Vec<(usize, &str)>>();
+    /// let b: &[_] = &[(0, "The"), (4, "quick"), (12, "brown"), (20, "fox"), (24, "can't"),
+    ///                 (30, "jump"), (35, "32.3"), (40, "feet"), (46, "right")];
+    ///
+    /// assert_eq!(&uwi1[..], b);
+    /// ```
+    fn unicode_word_indices<'a>(&'a self) -> UnicodeWordIndices<'a>;
 
     /// Returns an iterator over substrings of `self` separated on
     /// [UAX#29 word boundaries](http://www.unicode.org/reports/tr29/#Word_Boundaries).
@@ -247,6 +271,11 @@ impl UnicodeSegmentation for str {
     #[inline]
     fn unicode_words(&self) -> UnicodeWords {
         word::new_unicode_words(self)
+    }
+
+    #[inline]
+    fn unicode_word_indices(&self) -> UnicodeWordIndices {
+        word::new_unicode_word_indices(self)
     }
 
     #[inline]


### PR DESCRIPTION
The PR adds a new iterator: `UnicodeWordIndices` (and the function `unicode_word_indices`). It is similar to `UnicodeWords` but also provides byte offsets for each word.

The motivation for this PR was making https://github.com/jonathandturner/reedline/pull/5 in which I used `split_word_bound_indices` and then filtered the result using logic that is internal to `unicode_words`. I believe that PR would have been trivial using `unicode_word_indices`. Hopefully it can also be useful to others.

Should I add more tests for `unicode_word_indices`? Or are the existing tests for `unicode_words` and the doc test for `unicode_word_indices` sufficient?
