### PR TITLE
Increase the #[inline] opportunities - 15-40% performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ no_std = [] # This is a no-op, preserved for backward compatibility only.
 
 [dev-dependencies]
 quickcheck = "0.7"
-bencher = "0.1"
+criterion = "0.3"
 
 [[bench]]
 name = "graphemes"

--- a/benches/graphemes.rs
+++ b/benches/graphemes.rs
@@ -7,7 +7,7 @@ use unicode_segmentation::UnicodeSegmentation;
 fn graphemes(c: &mut Criterion, lang: &str, path: &str) {
     let text = fs::read_to_string(path).unwrap();
 
-    c.bench_function(&format!("grapheme {}",lang), |bench| {
+    c.bench_function(&format!("graphemes_{}",lang), |bench| {
         bench.iter(|| {
             for g in UnicodeSegmentation::graphemes(black_box(&*text), true) {
                 black_box(g);

--- a/benches/graphemes.rs
+++ b/benches/graphemes.rs
@@ -1,55 +1,54 @@
-#[macro_use]
-extern crate bencher;
-extern crate unicode_segmentation;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use unicode_segmentation;
 
-use bencher::Bencher;
-use unicode_segmentation::UnicodeSegmentation;
 use std::fs;
+use unicode_segmentation::UnicodeSegmentation;
 
-fn graphemes(bench: &mut Bencher, path: &str) {
+fn graphemes(c: &mut Criterion, lang: &str, path: &str) {
     let text = fs::read_to_string(path).unwrap();
-    bench.iter(|| {
-        for g in UnicodeSegmentation::graphemes(&*text, true) {
-            bencher::black_box(g);
-        }
+
+    c.bench_function(&format!("grapheme {}",lang), |bench| {
+        bench.iter(|| {
+            for g in UnicodeSegmentation::graphemes(black_box(&*text), true) {
+                black_box(g);
+            }
+        })
     });
-
-    bench.bytes = text.len() as u64;
 }
 
-fn graphemes_arabic(bench: &mut Bencher) {
-    graphemes(bench, "benches/texts/arabic.txt");
+fn graphemes_arabic(c: &mut Criterion) {
+    graphemes(c, "arabic" ,"benches/texts/arabic.txt");
 }
 
-fn graphemes_english(bench: &mut Bencher) {
-    graphemes(bench, "benches/texts/english.txt");
+fn graphemes_english(c: &mut Criterion) {
+    graphemes(c, "english" ,"benches/texts/english.txt");
 }
 
-fn graphemes_hindi(bench: &mut Bencher) {
-    graphemes(bench, "benches/texts/hindi.txt");
+fn graphemes_hindi(c: &mut Criterion) {
+    graphemes(c, "hindi" ,"benches/texts/hindi.txt");
 }
 
-fn graphemes_japanese(bench: &mut Bencher) {
-    graphemes(bench, "benches/texts/japanese.txt");
+fn graphemes_japanese(c: &mut Criterion) {
+    graphemes(c, "japanese" ,"benches/texts/japanese.txt");
 }
 
-fn graphemes_korean(bench: &mut Bencher) {
-    graphemes(bench, "benches/texts/korean.txt");
+fn graphemes_korean(c: &mut Criterion) {
+    graphemes(c, "korean" ,"benches/texts/korean.txt");
 }
 
-fn graphemes_mandarin(bench: &mut Bencher) {
-    graphemes(bench, "benches/texts/mandarin.txt");
+fn graphemes_mandarin(c: &mut Criterion) {
+    graphemes(c, "mandarin" ,"benches/texts/mandarin.txt");
 }
 
-fn graphemes_russian(bench: &mut Bencher) {
-    graphemes(bench, "benches/texts/russian.txt");
+fn graphemes_russian(c: &mut Criterion) {
+    graphemes(c, "russian" ,"benches/texts/russian.txt");
 }
 
-fn graphemes_source_code(bench: &mut Bencher) {
-    graphemes(bench, "benches/texts/source_code.txt");
+fn graphemes_source_code(c: &mut Criterion) {
+    graphemes(c, "source_code","benches/texts/source_code.txt");
 }
 
-benchmark_group!(
+criterion_group!(
     benches,
     graphemes_arabic,
     graphemes_english,
@@ -61,4 +60,4 @@ benchmark_group!(
     graphemes_source_code,
 );
 
-benchmark_main!(benches);
+criterion_main!(benches);

--- a/src/grapheme.rs
+++ b/src/grapheme.rs
@@ -228,6 +228,7 @@ enum PairResult {
     Emoji,  // a break if preceded by emoji base and (Extend)*
 }
 
+#[inline]
 fn check_pair(before: GraphemeCat, after: GraphemeCat) -> PairResult {
     use crate::tables::grapheme::GraphemeCat::*;
     use self::PairResult::*;
@@ -407,6 +408,7 @@ impl GraphemeCursor {
         }
     }
 
+    #[inline]
     fn decide(&mut self, is_break: bool) {
         self.state = if is_break {
             GraphemeState::Break
@@ -415,11 +417,13 @@ impl GraphemeCursor {
         };
     }
 
+    #[inline]
     fn decision(&mut self, is_break: bool) -> Result<bool, GraphemeIncomplete> {
         self.decide(is_break);
         Ok(is_break)
     }
 
+    #[inline]
     fn is_boundary_result(&self) -> Result<bool, GraphemeIncomplete> {
         if self.state == GraphemeState::Break {
             Ok(true)
@@ -432,6 +436,7 @@ impl GraphemeCursor {
         }
     }
 
+    #[inline]
     fn handle_regional(&mut self, chunk: &str, chunk_start: usize) {
         use crate::tables::grapheme as gr;
         let mut ris_count = self.ris_count.unwrap_or(0);
@@ -452,6 +457,7 @@ impl GraphemeCursor {
         self.state = GraphemeState::Regional;
     }
 
+    #[inline]
     fn handle_emoji(&mut self, chunk: &str, chunk_start: usize) {
         use crate::tables::grapheme as gr;
         let mut iter = chunk.chars().rev();
@@ -482,6 +488,7 @@ impl GraphemeCursor {
         self.state = GraphemeState::Emoji;
     }
 
+    #[inline]
     /// Determine whether the current cursor location is a grapheme cluster boundary.
     /// Only a part of the string need be supplied. If `chunk_start` is nonzero or
     /// the length of `chunk` is not equal to `len` on creation, then this method
@@ -563,6 +570,7 @@ impl GraphemeCursor {
         }
     }
 
+    #[inline]
     /// Find the next boundary after the current cursor position. Only a part of
     /// the string need be supplied. If the chunk is incomplete, then this
     /// method might return `GraphemeIncomplete::PreContext` or


### PR DESCRIPTION
This PR increases the number of (internal) functions that are given an opportunity to be inlined during grapheme detection.
Benchmarking indicates that this change results in a significant performance improvement (see below).

This PR also replaces bencher with criterion to enable continued performance monitoring.

```
$ cargo criterion
   Compiling unicode-segmentation v1.7.1 (/home/tim/Open/unicode-segmentation)
    Finished bench [optimized] target(s) in 2.96s
Gnuplot not found, using plotters backend
Benchmarking graphemes_arabic: Collecting 100 samples in estimated 6.2276 s                                                                            graphemes_arabic         time:   [300.59 us 303.65 us 306.84 us]
                        change: [-28.120% -27.089% -26.073%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking graphemes_english: Collecting 100 samples in estimated 5.8875 s                                                                           graphemes_english        time:   [341.92 us 344.80 us 348.53 us]
                        change: [-43.442% -42.572% -41.739%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking graphemes_hindi: Collecting 100 samples in estimated 5.4019 s (                                                                           graphemes_hindi          time:   [340.59 us 343.50 us 346.90 us]
                        change: [-20.806% -19.540% -18.205%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking grapheme japanese: Collecting 100 samples in estimated 5.2540                                                                            graphemes_japanese       time:   [336.86 us 338.72 us 341.01 us]
                        change: [-23.941% -22.756% -21.497%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking graphemes_korean: Collecting 100 samples in estimated 6.8800 s                                                                            graphemes_korean         time:   [648.18 us 653.10 us 659.09 us]
                        change: [-18.605% -17.519% -16.332%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking graphemes_mandarin: Collecting 100 samples in estimated 6.0117                                                                            graphemes_mandarin       time:   [215.14 us 217.71 us 220.84 us]
                        change: [-29.560% -28.320% -27.072%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking graphemes_russian: Collecting 100 samples in estimated 6.3045 s                                                                           graphemes_russian        time:   [291.04 us 296.19 us 301.67 us]
                        change: [-28.801% -27.643% -26.482%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking graphemes_source_code: Collecting 100 samples in estimated 6.40                                                                           graphemes_source_code    time:   [378.38 us 383.62 us 389.18 us]
                        change: [-36.523% -35.751% -35.060%] (p = 0.00 < 0.05)
                        Performance has improved.

```