### PR TITLE
Adding missing size_hint for UnicodeSentences, UnicodeWords, and UnicodeWordIndices

### DIFF
--- a/src/sentence.rs
+++ b/src/sentence.rs
@@ -366,6 +366,11 @@ impl<'a> Iterator for UnicodeSentences<'a> {
     fn next(&mut self) -> Option<&'a str> {
         self.inner.next()
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 impl<'a> Iterator for USentenceBounds<'a> {

--- a/src/word.rs
+++ b/src/word.rs
@@ -36,6 +36,11 @@ impl<'a> Iterator for UnicodeWords<'a> {
     fn next(&mut self) -> Option<&'a str> {
         self.inner.next()
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 impl<'a> DoubleEndedIterator for UnicodeWords<'a> {
     #[inline]
@@ -67,6 +72,11 @@ impl<'a> Iterator for UnicodeWordIndices<'a> {
     #[inline]
     fn next(&mut self) -> Option<(usize, &'a str)> {
         self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
     }
 }
 impl<'a> DoubleEndedIterator for UnicodeWordIndices<'a> {


### PR DESCRIPTION
I don't expect this to noticeably impact performance either positively or negatively for most use-cases, especially because `Iterator::collect` relies on the lower bound of `size_hint` which will remain unchanged after this PR.

However the upper bound will go from `None` to `Some(upper)`, which may benefit downstream crates that use it as a heuristic for pre-allocation size.

Note also that I forwarded the implementation of `size_hint` to the inner iterator, which means it is UAX#29 agnostic. I'm not enough of a Unicode expert to know if e.g. word boundaries can be empty, so it may not be the tightest possible upper bound for longer strings.