### PR TITLE
Remove outdated documentation link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["kwantam <kwantam@gmail.com>", "Manish Goregaokar <manishsmail@gmail.
 edition = "2018"
 homepage = "https://github.com/unicode-rs/unicode-segmentation"
 repository = "https://github.com/unicode-rs/unicode-segmentation"
-documentation = "https://unicode-rs.github.io/unicode-segmentation"
 
 license = "MIT/Apache-2.0"
 keywords = ["text", "unicode", "grapheme", "word", "boundary"]


### PR DESCRIPTION
The documentation on `unicode-rs.github.io` hasn't been updated in three
years (since Travis CI stopped working), and docs.rs works fine for this
crate.