### PR TITLE
Implement Debug on all public structs

### DIFF
--- a/src/grapheme.rs
+++ b/src/grapheme.rs
@@ -19,7 +19,7 @@ use crate::tables::grapheme::GraphemeCat;
 ///
 /// [`grapheme_indices`]: trait.UnicodeSegmentation.html#tymethod.grapheme_indices
 /// [`UnicodeSegmentation`]: trait.UnicodeSegmentation.html
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct GraphemeIndices<'a> {
     start_offset: usize,
     iter: Graphemes<'a>,

--- a/src/sentence.rs
+++ b/src/sentence.rs
@@ -18,7 +18,7 @@ mod fwd {
 
     // Describe a parsed part of source string as described in this table:
     // https://unicode.org/reports/tr29/#Default_Sentence_Boundaries
-    #[derive(Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum StatePart {
         Sot,
         Eot,
@@ -33,7 +33,7 @@ mod fwd {
         STerm,
     }
 
-    #[derive(Clone, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     struct SentenceBreaksState(pub [StatePart; 4]);
 
     const INITIAL_STATE: SentenceBreaksState = SentenceBreaksState([
@@ -43,7 +43,7 @@ mod fwd {
         StatePart::Sot,
     ]);
 
-    #[derive(Clone)]
+    #[derive(Debug, Clone)]
     pub struct SentenceBreaks<'a> {
         pub string: &'a str,
         pos: usize,
@@ -296,7 +296,7 @@ mod fwd {
 ///
 /// [`unicode_sentences`]: trait.UnicodeSegmentation.html#tymethod.unicode_sentences
 /// [`UnicodeSegmentation`]: trait.UnicodeSegmentation.html
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct UnicodeSentences<'a> {
     inner: Filter<USentenceBounds<'a>, fn(&&str) -> bool>,
 }
@@ -309,7 +309,7 @@ pub struct UnicodeSentences<'a> {
 ///
 /// [`split_sentence_bounds`]: trait.UnicodeSegmentation.html#tymethod.split_sentence_bounds
 /// [`UnicodeSegmentation`]: trait.UnicodeSegmentation.html
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct USentenceBounds<'a> {
     iter: fwd::SentenceBreaks<'a>,
     sentence_start: Option<usize>,
@@ -322,7 +322,7 @@ pub struct USentenceBounds<'a> {
 ///
 /// [`split_sentence_bound_indices`]: trait.UnicodeSegmentation.html#tymethod.split_sentence_bound_indices
 /// [`UnicodeSegmentation`]: trait.UnicodeSegmentation.html
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct USentenceBoundIndices<'a> {
     start_offset: usize,
     iter: USentenceBounds<'a>,

--- a/src/word.rs
+++ b/src/word.rs
@@ -25,6 +25,7 @@ use crate::tables::word::WordCat;
 ///
 /// [`unicode_words`]: trait.UnicodeSegmentation.html#tymethod.unicode_words
 /// [`UnicodeSegmentation`]: trait.UnicodeSegmentation.html
+#[derive(Debug)]
 pub struct UnicodeWords<'a> {
     inner: Filter<UWordBounds<'a>, fn(&&str) -> bool>,
 }
@@ -62,6 +63,7 @@ impl<'a> DoubleEndedIterator for UnicodeWords<'a> {
 ///
 /// [`unicode_word_indices`]: trait.UnicodeSegmentation.html#tymethod.unicode_word_indices
 /// [`UnicodeSegmentation`]: trait.UnicodeSegmentation.html
+#[derive(Debug)]
 pub struct UnicodeWordIndices<'a> {
     inner: Filter<UWordBoundIndices<'a>, fn(&(usize, &str)) -> bool>,
 }
@@ -94,7 +96,7 @@ impl<'a> DoubleEndedIterator for UnicodeWordIndices<'a> {
 ///
 /// [`split_word_bounds`]: trait.UnicodeSegmentation.html#tymethod.split_word_bounds
 /// [`UnicodeSegmentation`]: trait.UnicodeSegmentation.html
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct UWordBounds<'a> {
     string: &'a str,
     cat: Option<WordCat>,
@@ -108,7 +110,7 @@ pub struct UWordBounds<'a> {
 ///
 /// [`split_word_bound_indices`]: trait.UnicodeSegmentation.html#tymethod.split_word_bound_indices
 /// [`UnicodeSegmentation`]: trait.UnicodeSegmentation.html
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct UWordBoundIndices<'a> {
     start_offset: usize,
     iter: UWordBounds<'a>,


### PR DESCRIPTION
Some types in this crate don't have Debug implemented, but it's annoying
to use a non-Debug type in a struct with Debug derived. I just used the
automatic impl from `#[derive(Debug)]` for all of these (although in the
future it might be good to have custom implementations for types with
complex internals).

Closes #95.