### PR TITLE
Add methods for mutable str references

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub use word::{UWordBoundIndices, UWordBounds, UnicodeWordIndices, UnicodeWords}
 mod grapheme;
 mod sentence;
 #[rustfmt::skip]
+mod str_ref;
 mod tables;
 mod word;
 
@@ -96,7 +97,11 @@ pub trait UnicodeSegmentation {
     ///
     /// assert_eq!(&gr2[..], b);
     /// ```
-    fn graphemes(&self, is_extended: bool) -> Graphemes<'_>;
+    // TODO: There are some breaking changes like this one.
+    fn graphemes(&self, is_extended: bool) -> Graphemes<&str>;
+
+    #[allow(missing_docs, unsafe_code)]
+    fn graphemes_mut(&mut self, is_extended: bool) -> Graphemes<&mut str>;
 
     /// Returns an iterator over the grapheme clusters of `self` and their
     /// byte offsets. See `graphemes()` for more information.
@@ -111,7 +116,7 @@ pub trait UnicodeSegmentation {
     ///
     /// assert_eq!(&gr_inds[..], b);
     /// ```
-    fn grapheme_indices(&self, is_extended: bool) -> GraphemeIndices<'_>;
+    fn grapheme_indices(&self, is_extended: bool) -> GraphemeIndices<&str>;
 
     /// Returns an iterator over the words of `self`, separated on
     /// [UAX#29 word boundaries](http://www.unicode.org/reports/tr29/#Word_Boundaries).
@@ -133,7 +138,10 @@ pub trait UnicodeSegmentation {
     ///
     /// assert_eq!(&uw1[..], b);
     /// ```
-    fn unicode_words(&self) -> UnicodeWords<'_>;
+    fn unicode_words(&self) -> UnicodeWords<&str>;
+
+    #[allow(missing_docs, unsafe_code)]
+    fn unicode_words_mut(&mut self) -> UnicodeWords<&mut str>;
 
     /// Returns an iterator over the words of `self`, separated on
     /// [UAX#29 word boundaries](http://www.unicode.org/reports/tr29/#Word_Boundaries), and their
@@ -157,7 +165,7 @@ pub trait UnicodeSegmentation {
     ///
     /// assert_eq!(&uwi1[..], b);
     /// ```
-    fn unicode_word_indices(&self) -> UnicodeWordIndices<'_>;
+    fn unicode_word_indices(&self) -> UnicodeWordIndices<&str>;
 
     /// Returns an iterator over substrings of `self` separated on
     /// [UAX#29 word boundaries](http://www.unicode.org/reports/tr29/#Word_Boundaries).
@@ -173,7 +181,7 @@ pub trait UnicodeSegmentation {
     ///
     /// assert_eq!(&swu1[..], b);
     /// ```
-    fn split_word_bounds(&self) -> UWordBounds<'_>;
+    fn split_word_bounds(&self) -> UWordBounds<&str>;
 
     /// Returns an iterator over substrings of `self`, split on UAX#29 word boundaries,
     /// and their offsets. See `split_word_bounds()` for more information.
@@ -188,7 +196,7 @@ pub trait UnicodeSegmentation {
     ///
     /// assert_eq!(&swi1[..], b);
     /// ```
-    fn split_word_bound_indices(&self) -> UWordBoundIndices<'_>;
+    fn split_word_bound_indices(&self) -> UWordBoundIndices<&str>;
 
     /// Returns an iterator over substrings of `self` separated on
     /// [UAX#29 sentence boundaries](http://www.unicode.org/reports/tr29/#Sentence_Boundaries).
@@ -248,32 +256,42 @@ pub trait UnicodeSegmentation {
 
 impl UnicodeSegmentation for str {
     #[inline]
-    fn graphemes(&self, is_extended: bool) -> Graphemes {
+    fn graphemes(&self, is_extended: bool) -> Graphemes<&str> {
         grapheme::new_graphemes(self, is_extended)
     }
 
     #[inline]
-    fn grapheme_indices(&self, is_extended: bool) -> GraphemeIndices {
+    fn graphemes_mut(&mut self, is_extended: bool) -> Graphemes<&mut str> {
+        grapheme::new_graphemes(self, is_extended)
+    }
+
+    #[inline]
+    fn grapheme_indices(&self, is_extended: bool) -> GraphemeIndices<&str> {
         grapheme::new_grapheme_indices(self, is_extended)
     }
 
     #[inline]
-    fn unicode_words(&self) -> UnicodeWords {
+    fn unicode_words(&self) -> UnicodeWords<&str> {
         word::new_unicode_words(self)
     }
 
     #[inline]
-    fn unicode_word_indices(&self) -> UnicodeWordIndices {
+    fn unicode_words_mut(&mut self) -> UnicodeWords<&mut str> {
+        word::new_unicode_words(self)
+    }
+
+    #[inline]
+    fn unicode_word_indices(&self) -> UnicodeWordIndices<&str> {
         word::new_unicode_word_indices(self)
     }
 
     #[inline]
-    fn split_word_bounds(&self) -> UWordBounds {
+    fn split_word_bounds(&self) -> UWordBounds<&str> {
         word::new_word_bounds(self)
     }
 
     #[inline]
-    fn split_word_bound_indices(&self) -> UWordBoundIndices {
+    fn split_word_bound_indices(&self) -> UWordBoundIndices<&str> {
         word::new_word_bound_indices(self)
     }
 

--- a/src/str_ref.rs
+++ b/src/str_ref.rs
@@ -1,0 +1,19 @@
+use core::ops::Deref;
+
+/// This trait is a common abstraction for &str and &mut str.
+/// It combines all the string operations that this crate relies on, such that our code can be written generically and applied to both.
+pub trait StrRef: Deref<Target = str> + Default {
+    fn split_at(self, idx: usize) -> (Self, Self);
+}
+
+impl StrRef for &str {
+    fn split_at(self, idx: usize) -> (Self, Self) {
+        self.split_at(idx)
+    }
+}
+
+impl StrRef for &mut str {
+    fn split_at(self, idx: usize) -> (Self, Self) {
+        self.split_at_mut(idx)
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -187,6 +187,31 @@ fn test_words() {
 }
 
 #[test]
+fn test_mutation() {
+    // Reversing the letters of each word, preserving grapheme clusters.
+    // We reverse the bytes inside each individual grapheme cluster first, such that they return to their original order when we reverse the bytes of the whole word.
+    let mut s = "abc def ghi".to_string();
+    for word in s.unicode_words_mut() {
+        for grapheme in word.graphemes_mut(true) {
+            unsafe { grapheme.as_bytes_mut().reverse() };
+        }
+        // If one wants to be precise, the call to `as_bytes_mut` is undefined behavior because `word` is not guaranteed to hold valid UTF-8 at this point.
+        unsafe { word.as_bytes_mut().reverse() };
+    }
+    assert_eq!(s, "cba fed ihg");
+
+    // Capitalizing each word
+    let mut input = "a big important title".to_string();
+    for word in input.unicode_words_mut() {
+        word.graphemes_mut(true)
+            .next()
+            .unwrap()
+            .make_ascii_uppercase();
+    }
+    assert_eq!(input, "A Big Important Title");
+}
+
+#[test]
 fn test_sentences() {
     use crate::testdata::TEST_SENTENCE;
 


### PR DESCRIPTION
There are use cases, such as capitalizing the first letter of each word or reversing the order of words, where it would be handy to have mutable references to those elements to apply the operation in place. To address this, I have added unicode_words_mut and graphemes_mut, which provide this functionality.

To generalize the existing code for mutable references, I have introduced a StrRef trait as a common interface for &str and &mut str.

I have modified the implementation of Graphemes to remove the two grapheme cursors it previously held. Instead, I now create new cursors as needed. This change was necessary because, during iteration, the cursors would request context from the previous grapheme while ownership of that part of the string had already been transferred. I don't know Unicode well enough to determine whether this new approach alters behavior, but all tests still pass. If this solution is correct, it appears to be the better approach since it avoids redundant checks.

Since the string operations that can be performed in place are limited, I am unsure how useful this PR would be in practice. However, I feel it could be a reasonable addition to the library.